### PR TITLE
spawn: Function overload forwards stack allocator

### DIFF
--- a/include/spawn/impl/spawn.hpp
+++ b/include/spawn/impl/spawn.hpp
@@ -334,7 +334,8 @@ auto spawn(Function&& function, StackAllocator&& salloc)
 {
   auto ex = detail::net::get_associated_executor(function);
 
-  spawn(ex, std::forward<Function>(function), salloc);
+  spawn(ex, std::forward<Function>(function),
+        std::forward<StackAllocator>(salloc));
 }
 
 template <typename Handler, typename Function, typename StackAllocator>

--- a/test/test_spawn.cc
+++ b/test/test_spawn.cc
@@ -41,6 +41,16 @@ TEST(Spawn, SpawnFunction)
   ASSERT_EQ(1, called);
 }
 
+TEST(Spawn, SpawnBoundFunction)
+{
+  boost::asio::io_context ioc;
+  int called = 0;
+  spawn::spawn(bind_executor(ioc.get_executor(), counting_handler(called)));
+  ASSERT_EQ(1, ioc.run());
+  ASSERT_TRUE(ioc.stopped());
+  ASSERT_EQ(1, called);
+}
+
 TEST(Spawn, SpawnFunctionStackAllocator)
 {
   boost::asio::io_context ioc;


### PR DESCRIPTION
address sanitizer caught this as "stack-use-after-scope" when calling allocate() on the copy of salloc