### PR TITLE
spawn_helper: rethrow exceptions outside of callcc()

### DIFF
--- a/test/test_spawn.cc
+++ b/test/test_spawn.cc
@@ -236,3 +236,17 @@ TEST(Spawn, SpawnTimerDestruct)
   }
   ASSERT_EQ(0, called);
 }
+
+struct throwing_handler {
+  template <typename T>
+  void operator()(spawn::basic_yield_context<T>) {
+    throw std::runtime_error("");
+  }
+};
+
+TEST(Spawn, SpawnException)
+{
+  boost::asio::io_context ioc;
+  spawn::spawn(ioc, throwing_handler());
+  EXPECT_THROW(ioc.run_one(), std::runtime_error);
+}


### PR DESCRIPTION
from boost::context documentation for callcc():

> If the function executed inside a context-function emits an exception,
  the application is terminated by calling std::terminate().
  std::exception_ptr can be used to transfer exceptions between different
  continuations.

Fixes: https://github.com/cbodley/spawn/issues/1