### PR TITLE
yield context supports handlers with multiple arguments

### DIFF
--- a/include/spawn/impl/spawn.hpp
+++ b/include/spawn/impl/spawn.hpp
@@ -14,6 +14,7 @@
 
 #include <atomic>
 #include <memory>
+#include <tuple>
 
 #include <boost/system/system_error.hpp>
 #include <boost/context/continuation.hpp>
@@ -39,8 +40,47 @@ namespace detail {
     }
   };
 
-  template <typename Handler, typename T>
+  template <typename Handler, typename ...Ts>
   class coro_handler
+  {
+  public:
+    coro_handler(basic_yield_context<Handler> ctx)
+      : callee_(ctx.callee_.lock()),
+        caller_(ctx.caller_),
+        handler_(ctx.handler_),
+        ready_(0),
+        ec_(ctx.ec_),
+        value_(0)
+    {
+    }
+
+    void operator()(Ts... values)
+    {
+      *ec_ = boost::system::error_code();
+      *value_ = std::forward_as_tuple(std::move(values)...);
+      if (--*ready_ == 0)
+        callee_->resume();
+    }
+
+    void operator()(boost::system::error_code ec, Ts... values)
+    {
+      *ec_ = ec;
+      *value_ = std::forward_as_tuple(std::move(values)...);
+      if (--*ready_ == 0)
+        callee_->resume();
+    }
+
+  //private:
+    std::shared_ptr<continuation_context> callee_;
+    continuation_context& caller_;
+    Handler handler_;
+    std::atomic<long>* ready_;
+    boost::system::error_code* ec_;
+    std::tuple<Ts...>* value_;
+  };
+
+  template <typename Handler, typename T>
+  class coro_handler<Handler, T>
   {
   public:
     coro_handler(basic_yield_context<Handler> ctx)
@@ -113,8 +153,46 @@ namespace detail {
     boost::system::error_code* ec_;
   };
 
-  template <typename Handler, typename T>
+  template <typename Handler, typename ...Ts>
   class coro_async_result
+  {
+  public:
+    using completion_handler_type = coro_handler<Handler, Ts...>;
+    using return_type = std::tuple<Ts...>;
+
+    explicit coro_async_result(completion_handler_type& h)
+      : handler_(h),
+        caller_(h.caller_),
+        ready_(2)
+    {
+      h.ready_ = &ready_;
+      out_ec_ = h.ec_;
+      if (!out_ec_) h.ec_ = &ec_;
+      h.value_ = &value_;
+    }
+
+    return_type get()
+    {
+      // Must not hold shared_ptr while suspended.
+      handler_.callee_.reset();
+
+      if (--ready_ != 0)
+        caller_.resume(); // suspend caller
+      if (!out_ec_ && ec_) throw boost::system::system_error(ec_);
+      return std::move(value_);
+    }
+
+  private:
+    completion_handler_type& handler_;
+    continuation_context& caller_;
+    std::atomic<long> ready_;
+    boost::system::error_code* out_ec_;
+    boost::system::error_code ec_;
+    return_type value_;
+  };
+
+  template <typename Handler, typename T>
+  class coro_async_result<Handler, T>
   {
   public:
     using completion_handler_type = coro_handler<Handler, T>;
@@ -204,15 +282,15 @@ public:
   }
 };
 
-template <typename Handler, typename ReturnType, typename Arg1>
-class SPAWN_NET_NAMESPACE::async_result<spawn::basic_yield_context<Handler>, ReturnType(Arg1)>
-  : public spawn::detail::coro_async_result<Handler, typename std::decay<Arg1>::type>
+template <typename Handler, typename ReturnType, typename ...Args>
+class SPAWN_NET_NAMESPACE::async_result<spawn::basic_yield_context<Handler>, ReturnType(Args...)>
+  : public spawn::detail::coro_async_result<Handler, typename std::decay<Args>::type...>
 {
 public:
   explicit async_result(
     typename spawn::detail::coro_async_result<Handler,
-      typename std::decay<Arg1>::type>::completion_handler_type& h)
-    : spawn::detail::coro_async_result<Handler, typename std::decay<Arg1>::type>(h)
+      typename std::decay<Args>::type...>::completion_handler_type& h)
+    : spawn::detail::coro_async_result<Handler, typename std::decay<Args>::type...>(h)
   {
   }
 };
@@ -231,38 +309,38 @@ public:
   }
 };
 
-template <typename Handler, typename ReturnType, typename Arg2>
+template <typename Handler, typename ReturnType, typename ...Args>
 class SPAWN_NET_NAMESPACE::async_result<spawn::basic_yield_context<Handler>,
-    ReturnType(boost::system::error_code, Arg2)>
-  : public spawn::detail::coro_async_result<Handler, typename std::decay<Arg2>::type>
+    ReturnType(boost::system::error_code, Args...)>
+  : public spawn::detail::coro_async_result<Handler, typename std::decay<Args>::type...>
 {
 public:
   explicit async_result(
     typename spawn::detail::coro_async_result<Handler,
-      typename std::decay<Arg2>::type>::completion_handler_type& h)
-    : spawn::detail::coro_async_result<Handler, typename std::decay<Arg2>::type>(h)
+      typename std::decay<Args>::type...>::completion_handler_type& h)
+    : spawn::detail::coro_async_result<Handler, typename std::decay<Args>::type...>(h)
   {
   }
 };
 
-template <typename Handler, typename T, typename Allocator>
-struct SPAWN_NET_NAMESPACE::associated_allocator<spawn::detail::coro_handler<Handler, T>, Allocator>
+template <typename Handler, typename Allocator, typename ...Ts>
+struct SPAWN_NET_NAMESPACE::associated_allocator<spawn::detail::coro_handler<Handler, Ts...>, Allocator>
 {
   using type = associated_allocator_t<Handler, Allocator>;
 
-  static type get(const spawn::detail::coro_handler<Handler, T>& h,
+  static type get(const spawn::detail::coro_handler<Handler, Ts...>& h,
       const Allocator& a = Allocator()) noexcept
   {
     return associated_allocator<Handler, Allocator>::get(h.handler_, a);
   }
 };
 
-template <typename Handler, typename T, typename Executor>
-struct SPAWN_NET_NAMESPACE::associated_executor<spawn::detail::coro_handler<Handler, T>, Executor>
+template <typename Handler, typename Executor, typename ...Ts>
+struct SPAWN_NET_NAMESPACE::associated_executor<spawn::detail::coro_handler<Handler, Ts...>, Executor>
 {
   using type = associated_executor_t<Handler, Executor>;
 
-  static type get(const spawn::detail::coro_handler<Handler, T>& h,
+  static type get(const spawn::detail::coro_handler<Handler, Ts...>& h,
       const Executor& ex = Executor()) noexcept
   {
     return associated_executor<Handler, Executor>::get(h.handler_, ex);

--- a/include/spawn/impl/spawn.hpp
+++ b/include/spawn/impl/spawn.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/system/system_error.hpp>
 #include <boost/context/continuation.hpp>
+#include <boost/optional.hpp>
 
 #include <spawn/detail/net.hpp>
 #include <spawn/detail/is_stack_allocator.hpp>
@@ -76,7 +77,7 @@ namespace detail {
     Handler handler_;
     std::atomic<long>* ready_;
     boost::system::error_code* ec_;
-    std::tuple<Ts...>* value_;
+    boost::optional<std::tuple<Ts...>>* value_;
   };
 
   template <typename Handler, typename T>
@@ -115,7 +116,7 @@ namespace detail {
     Handler handler_;
     std::atomic<long>* ready_;
     boost::system::error_code* ec_;
-    T* value_;
+    boost::optional<T>* value_;
   };
 
   template <typename Handler>
@@ -179,7 +180,7 @@ namespace detail {
       if (--ready_ != 0)
         caller_.resume(); // suspend caller
       if (!out_ec_ && ec_) throw boost::system::system_error(ec_);
-      return std::move(value_);
+      return std::move(*value_);
     }
 
   private:
@@ -188,7 +189,7 @@ namespace detail {
     std::atomic<long> ready_;
     boost::system::error_code* out_ec_;
     boost::system::error_code ec_;
-    return_type value_;
+    boost::optional<return_type> value_;
   };
 
   template <typename Handler, typename T>
@@ -217,7 +218,7 @@ namespace detail {
       if (--ready_ != 0)
         caller_.resume(); // suspend caller
       if (!out_ec_ && ec_) throw boost::system::system_error(ec_);
-      return std::move(value_);
+      return std::move(*value_);
     }
 
   private:
@@ -226,7 +227,7 @@ namespace detail {
     std::atomic<long> ready_;
     boost::system::error_code* out_ec_;
     boost::system::error_code ec_;
-    return_type value_;
+    boost::optional<return_type> value_;
   };
 
   template <typename Handler>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,10 @@ if(SPAWN_TEST_ADDRESS_SANITIZER)
 	target_link_libraries(test_base INTERFACE "-fsanitize=address")
 endif()
 
+add_executable(test_async_result test_async_result.cc)
+target_link_libraries(test_async_result test_base spawn)
+add_test(test_async_result test_async_result)
+
 add_executable(test_spawn test_spawn.cc)
 target_link_libraries(test_spawn test_base spawn)
 add_test(test_spawn test_spawn)

--- a/test/test_async_result.cc
+++ b/test/test_async_result.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 Casey Bodley (cbodley at redhat dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <spawn/spawn.hpp>
+
+// make assertions about async_result::return_type with different signatures
+// this is a compilation test only
+
+template <typename Sig>
+struct yield_result : boost::asio::async_result<spawn::yield_context, Sig> {};
+
+template <typename T, typename Sig>
+struct yield_returns : std::is_same<T, typename yield_result<Sig>::return_type> {};
+
+// no return value
+static_assert(yield_returns<void, void()>::value,
+              "wrong return value for void()");
+static_assert(yield_returns<void, void(boost::system::error_code)>::value,
+              "wrong return value for void(error_code)");
+// single-parameter return value
+static_assert(yield_returns<int, void(int)>::value,
+              "wrong return value for void(int)");
+static_assert(yield_returns<int, void(boost::system::error_code, int)>::value,
+              "wrong return value for void(error_code, int)");
+// single-tuple-parameter return value
+static_assert(yield_returns<std::tuple<int, std::string>,
+                            void(std::tuple<int, std::string>)>::value,
+              "wrong return value for void(std::tuple<int>)");
+static_assert(yield_returns<std::tuple<int, std::string>,
+                            void(boost::system::error_code, std::tuple<int, std::string>)>::value,
+              "wrong return value for void(error_code, std::tuple<int>)");
+// single-pair-parameter return value
+static_assert(yield_returns<std::pair<int, std::string>,
+                            void(std::pair<int, std::string>)>::value,
+              "wrong return value for void(std::tuple<int>)");
+static_assert(yield_returns<std::pair<int, std::string>,
+                            void(boost::system::error_code, std::pair<int, std::string>)>::value,
+              "wrong return value for void(error_code, std::tuple<int>)");

--- a/test/test_async_result.cc
+++ b/test/test_async_result.cc
@@ -25,6 +25,13 @@ static_assert(yield_returns<int, void(int)>::value,
               "wrong return value for void(int)");
 static_assert(yield_returns<int, void(boost::system::error_code, int)>::value,
               "wrong return value for void(error_code, int)");
+// multiple-parameter return value
+static_assert(yield_returns<std::tuple<int, std::string>,
+                            void(int, std::string)>::value,
+              "wrong return value for void(int, string)");
+static_assert(yield_returns<std::tuple<int, std::string>,
+                            void(boost::system::error_code, int, std::string)>::value,
+              "wrong return value for void(error_code, int, string)");
 // single-tuple-parameter return value
 static_assert(yield_returns<std::tuple<int, std::string>,
                             void(std::tuple<int, std::string>)>::value,

--- a/test/test_spawn.cc
+++ b/test/test_spawn.cc
@@ -246,3 +246,93 @@ TEST(Spawn, SpawnTimerDestruct)
   }
   ASSERT_EQ(0, called);
 }
+
+using boost::system::error_code;
+
+template <typename Handler, typename ...Args>
+void post(Handler& h, Args&& ...args)
+{
+  auto ex = boost::asio::get_associated_executor(h);
+  auto a = boost::asio::get_associated_allocator(h);
+  auto b = std::bind(std::move(h), std::forward<Args>(args)...);
+  ex.post(std::move(b), a);
+}
+
+struct single_tuple_handler {
+  std::tuple<int, std::string>& result;
+  void operator()(spawn::yield_context y) {
+    using Signature = void(std::tuple<int, std::string>);
+    boost::asio::async_completion<spawn::yield_context, Signature> init(y);
+    post(init.completion_handler, std::make_tuple(42, std::string{"test"}));
+    result = init.result.get();
+  }
+};
+
+TEST(Spawn, ReturnSingleTuple)
+{
+  boost::asio::io_context ioc;
+  std::tuple<int, std::string> result;
+  spawn::spawn(ioc, single_tuple_handler{result});
+  ASSERT_EQ(2, ioc.poll());
+  EXPECT_EQ(std::make_tuple(42, std::string{"test"}), result);
+}
+
+struct multiple2_handler {
+  std::tuple<int, std::string>& result;
+  void operator()(spawn::yield_context y) {
+    using Signature = void(error_code, int, std::string);
+    boost::asio::async_completion<spawn::yield_context, Signature> init(y);
+    post(init.completion_handler, error_code{}, 42, std::string{"test"});
+    result = init.result.get();
+  }
+};
+
+TEST(Spawn, ReturnMultiple2)
+{
+  boost::asio::io_context ioc;
+  std::tuple<int, std::string> result;
+  spawn::spawn(ioc, multiple2_handler{result});
+  ASSERT_EQ(2, ioc.poll());
+  EXPECT_EQ(std::make_tuple(42, std::string{"test"}), result);
+}
+
+struct multiple2_with_moveonly_handler {
+  std::tuple<int, std::unique_ptr<int>>& result;
+  void operator()(spawn::yield_context y) {
+    using Signature = void(int, std::unique_ptr<int>);
+    boost::asio::async_completion<spawn::yield_context, Signature> init(y);
+    std::unique_ptr<int> ptr{new int(42)};
+    init.completion_handler(42, std::move(ptr));
+    result = init.result.get();
+  }
+};
+
+TEST(Spawn, ReturnMultiple2MoveOnly)
+{
+  boost::asio::io_context ioc;
+  std::tuple<int, std::unique_ptr<int>> result;
+  spawn::spawn(ioc, multiple2_with_moveonly_handler{result});
+  ASSERT_EQ(1, ioc.poll());
+  EXPECT_EQ(42, std::get<0>(result));
+  ASSERT_TRUE(std::get<1>(result));
+  EXPECT_EQ(42, *std::get<1>(result));
+}
+
+struct multiple3_handler {
+  std::tuple<int, std::string, double>& result;
+  void operator()(spawn::yield_context y) {
+    using Signature = void(error_code, int, std::string, double);
+    boost::asio::async_completion<spawn::yield_context, Signature> init(y);
+    post(init.completion_handler, error_code{}, 42, std::string{"test"}, 2.0);
+    result = init.result.get();
+  }
+};
+
+TEST(Spawn, ReturnMultiple3)
+{
+  boost::asio::io_context ioc;
+  std::tuple<int, std::string, double> result;
+  spawn::spawn(ioc, multiple3_handler{result});
+  ASSERT_EQ(2, ioc.poll());
+  EXPECT_EQ(std::make_tuple(42, std::string{"test"}, 2.0), result);
+}


### PR DESCRIPTION
turns coro_handler and coro_async_result into variadic templates. whenever coro_handler gets more than one value to return, it stores those values in a std::tuple that gets returned by coro_async_result