### PR TITLE
spawn: rethrow exceptions in coro_handler

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,3 +19,7 @@ endif()
 add_executable(test_spawn test_spawn.cc)
 target_link_libraries(test_spawn test_base spawn)
 add_test(test_spawn test_spawn)
+
+add_executable(test_exception test_exception.cc)
+target_link_libraries(test_exception test_base spawn)
+add_test(test_exception test_exception)

--- a/test/test_exception.cc
+++ b/test/test_exception.cc
@@ -1,0 +1,142 @@
+//
+// test_exception.cpp
+// ~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2020 Casey Bodley (cbodley at redhat dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <spawn/spawn.hpp>
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+#include <gtest/gtest.h>
+
+
+struct throwing_handler {
+  template <typename T>
+  void operator()(spawn::basic_yield_context<T>) {
+    throw std::runtime_error("");
+  }
+};
+
+TEST(Exception, SpawnThrowInHelper)
+{
+  boost::asio::io_context ioc;
+  spawn::spawn(ioc, throwing_handler());
+  EXPECT_THROW(ioc.run_one(), std::runtime_error); // spawn->throw
+}
+
+struct noop_handler {
+  template <typename T>
+  void operator()(spawn::basic_yield_context<T>) {}
+};
+
+struct throwing_completion_handler {
+  void operator()() {
+    throw std::runtime_error("");
+  }
+};
+
+TEST(Exception, SpawnHandlerThrowInHelper)
+{
+  boost::asio::io_context ioc;
+  spawn::spawn(bind_executor(ioc.get_executor(),
+                             throwing_completion_handler()),
+               noop_handler());
+  EXPECT_THROW(ioc.run_one(), std::runtime_error); // spawn->throw
+}
+
+template <typename CompletionToken>
+auto async_yield(CompletionToken&& token)
+  -> BOOST_ASIO_INITFN_RESULT_TYPE(CompletionToken, void())
+{
+  boost::asio::async_completion<CompletionToken, void()> init(token);
+  boost::asio::post(std::move(init.completion_handler));
+  return init.result.get();
+}
+
+struct yield_throwing_handler {
+  template <typename T>
+  void operator()(spawn::basic_yield_context<T> y) {
+    async_yield(y); // suspend and resume before throwing
+    throw std::runtime_error("");
+  }
+};
+
+TEST(Exception, SpawnThrowAfterYield)
+{
+  boost::asio::io_context ioc;
+  spawn::spawn(ioc, yield_throwing_handler());
+  ASSERT_NO_THROW(ioc.run_one()); // yield_throwing_handler suspend
+  EXPECT_THROW(ioc.run_one(), std::runtime_error); // resume + throw
+}
+
+struct yield_handler {
+  template <typename T>
+  void operator()(spawn::basic_yield_context<T> y) {
+    async_yield(y);
+  }
+};
+
+TEST(Exception, SpawnHandlerThrowAfterYield)
+{
+  boost::asio::io_context ioc;
+  spawn::spawn(bind_executor(ioc.get_executor(),
+                             throwing_completion_handler()),
+               yield_handler());
+  ASSERT_NO_THROW(ioc.run_one()); // yield_handler suspend
+  EXPECT_THROW(ioc.run_one(), std::runtime_error); // resume + throw
+}
+
+struct nested_throwing_handler {
+  template <typename T>
+  void operator()(spawn::basic_yield_context<T> y) {
+    spawn::spawn(y, throwing_handler());
+  }
+};
+
+TEST(Exception, SpawnThrowInNestedHelper)
+{
+  boost::asio::io_context ioc;
+  spawn::spawn(ioc, nested_throwing_handler());
+  EXPECT_THROW(ioc.run_one(), std::runtime_error); // spawn->spawn->throw
+}
+
+struct yield_nested_throwing_handler {
+  template <typename T>
+  void operator()(spawn::basic_yield_context<T> y) {
+    async_yield(y); // suspend and resume before spawning
+    spawn::spawn(y, yield_throwing_handler());
+  }
+};
+
+TEST(Exception, SpawnThrowAfterNestedYield)
+{
+  boost::asio::io_context ioc;
+  spawn::spawn(ioc, yield_nested_throwing_handler());
+  ASSERT_NO_THROW(ioc.run_one()); // yield_nested_throwing_handler suspend
+  ASSERT_NO_THROW(ioc.run_one()); // yield_throwing_handler suspend
+  EXPECT_THROW(ioc.run_one(), std::runtime_error); // resume + throw
+}
+
+struct yield_throw_after_nested_handler {
+  template <typename T>
+  void operator()(spawn::basic_yield_context<T> y) {
+    async_yield(y); // suspend and resume before spawning
+    spawn::spawn(y, yield_handler());
+    throw std::runtime_error("");
+  }
+};
+
+TEST(Exception, SpawnThrowAfterNestedSpawn)
+{
+  boost::asio::io_context ioc;
+  spawn::spawn(ioc, yield_throw_after_nested_handler());
+  ASSERT_NO_THROW(ioc.run_one()); // yield_throw_after_nested_handler suspend
+  EXPECT_THROW(ioc.run_one(), std::runtime_error); // resume + throw
+  EXPECT_EQ(1, ioc.poll()); // yield_handler resume
+  EXPECT_TRUE(ioc.stopped());
+}

--- a/test/test_spawn.cc
+++ b/test/test_spawn.cc
@@ -246,17 +246,3 @@ TEST(Spawn, SpawnTimerDestruct)
   }
   ASSERT_EQ(0, called);
 }
-
-struct throwing_handler {
-  template <typename T>
-  void operator()(spawn::basic_yield_context<T>) {
-    throw std::runtime_error("");
-  }
-};
-
-TEST(Spawn, SpawnException)
-{
-  boost::asio::io_context ioc;
-  spawn::spawn(ioc, throwing_handler());
-  EXPECT_THROW(ioc.run_one(), std::runtime_error);
-}


### PR DESCRIPTION
the previous change only propagated exceptions that were thrown directly within the spawn_helper handler. once the spawned coroutine function suspends, the spawn_helper will have destructed. exceptions caught after that need to be rethrown once control returns to coro_handler