### PR TITLE
spawn: use any_io_executor for building with BOOST_ASIO_NO_TS_EXECUTORS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/dependency/googletest"]
-	path = test/dependency/googletest
-	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# requires boost 1.66, but may be provided by a parent project
-if(NOT Boost_FOUND OR NOT Boost_system_FOUND OR NOT Boost_context_FOUND OR Boost_VERSION VERSION_LESS 1.66.0)
-	find_package(Boost 1.66 REQUIRED COMPONENTS system context)
+# requires boost 1.74, but may be provided by a parent project
+if(NOT Boost_FOUND OR NOT Boost_system_FOUND OR NOT Boost_context_FOUND OR Boost_VERSION VERSION_LESS 1.74.0)
+	find_package(Boost 1.74 REQUIRED COMPONENTS system context)
 endif()
 
 add_library(spawn INTERFACE)

--- a/include/spawn/detail/net.hpp
+++ b/include/spawn/detail/net.hpp
@@ -35,6 +35,7 @@ using boost::asio::executor;
 using boost::asio::executor_binder;
 using boost::asio::is_executor;
 
+using boost::asio::make_strand;
 using boost::asio::strand;
 
 } // namespace net

--- a/include/spawn/detail/net.hpp
+++ b/include/spawn/detail/net.hpp
@@ -10,11 +10,11 @@
 
 #pragma once
 
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/associated_allocator.hpp>
 #include <boost/asio/associated_executor.hpp>
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/bind_executor.hpp>
-#include <boost/asio/executor.hpp>
 #include <boost/asio/is_executor.hpp>
 #include <boost/asio/strand.hpp>
 
@@ -30,10 +30,10 @@ using boost::asio::get_associated_executor;
 using boost::asio::associated_allocator_t;
 using boost::asio::get_associated_allocator;
 
+using boost::asio::any_io_executor;
 using boost::asio::execution_context;
-using boost::asio::executor;
 using boost::asio::executor_binder;
-using boost::asio::is_executor;
+using boost::asio::execution::is_executor;
 
 using boost::asio::make_strand;
 using boost::asio::strand;

--- a/include/spawn/impl/spawn.hpp
+++ b/include/spawn/impl/spawn.hpp
@@ -481,7 +481,7 @@ auto spawn(const Executor& ex, Function&& function, StackAllocator&& salloc)
   -> typename std::enable_if<detail::net::is_executor<Executor>::value &&
        detail::is_stack_allocator<typename std::decay<StackAllocator>::type>::value>::type
 {
-  spawn(detail::net::strand<Executor>(ex),
+  spawn(detail::net::make_strand(ex),
       std::forward<Function>(function),
       std::forward<StackAllocator>(salloc));
 }

--- a/include/spawn/impl/spawn.hpp
+++ b/include/spawn/impl/spawn.hpp
@@ -411,6 +411,18 @@ namespace detail {
         std::rethrow_exception(std::move(callee_->eptr_));
     }
 
+    using executor_type = detail::net::associated_executor_t<Handler>;
+    executor_type get_executor() const
+    {
+      return detail::net::get_associated_executor(data_->handler_);
+    }
+
+    using allocator_type = detail::net::associated_allocator_t<Handler>;
+    allocator_type get_allocator() const
+    {
+      return detail::net::get_associated_allocator(data_->handler_);
+    }
+
     std::shared_ptr<continuation_context> callee_;
     std::shared_ptr<spawn_data<Handler, Function, StackAllocator> > data_;
   };
@@ -440,9 +452,6 @@ auto spawn(Handler&& handler, Function&& function, StackAllocator&& salloc)
   using handler_type = typename std::decay<Handler>::type;
   using function_type = typename std::decay<Function>::type;
 
-  auto ex = detail::net::get_associated_executor(handler);
-  auto a = detail::net::get_associated_allocator(handler);
-
   detail::spawn_helper<handler_type, function_type, StackAllocator> helper;
   helper.data_ = std::make_shared<
       detail::spawn_data<handler_type, function_type, StackAllocator> >(
@@ -450,7 +459,7 @@ auto spawn(Handler&& handler, Function&& function, StackAllocator&& salloc)
         std::forward<Function>(function),
         std::forward<StackAllocator>(salloc));
 
-  ex.dispatch(helper, a);
+  boost::asio::dispatch(helper);
 }
 
 template <typename Handler, typename Function, typename StackAllocator>
@@ -463,9 +472,6 @@ auto spawn(basic_yield_context<Handler> ctx, Function&& function,
 
   Handler handler(ctx.handler_); // Explicit copy that might be moved from.
 
-  auto ex = detail::net::get_associated_executor(handler);
-  auto a = detail::net::get_associated_allocator(handler);
-
   detail::spawn_helper<Handler, function_type, StackAllocator> helper;
   helper.data_ = std::make_shared<
       detail::spawn_data<Handler, function_type, StackAllocator> >(
@@ -473,7 +479,7 @@ auto spawn(basic_yield_context<Handler> ctx, Function&& function,
         std::forward<Function>(function),
         std::forward<StackAllocator>(salloc));
 
-  ex.dispatch(helper, a);
+  boost::asio::dispatch(helper);
 }
 
 template <typename Function, typename Executor, typename StackAllocator>

--- a/include/spawn/spawn.hpp
+++ b/include/spawn/spawn.hpp
@@ -120,7 +120,7 @@ private:
 using yield_context = basic_yield_context<unspecified>;
 #else // defined(GENERATING_DOCUMENTATION)
 using yield_context = basic_yield_context<
-  detail::net::executor_binder<void(*)(), detail::net::executor>>;
+  detail::net::executor_binder<void(*)(), detail::net::any_io_executor>>;
 #endif // defined(GENERATING_DOCUMENTATION)
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_subdirectory(dependency)
+find_package(GTest REQUIRED)
 
 add_library(test_base INTERFACE)
-target_link_libraries(test_base INTERFACE gtest_main)
+target_link_libraries(test_base INTERFACE GTest::Main)
 
 # all warnings as errors
 if(MSVC)

--- a/test/dependency/CMakeLists.txt
+++ b/test/dependency/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(googletest)

--- a/test/test_spawn.cc
+++ b/test/test_spawn.cc
@@ -254,9 +254,8 @@ template <typename Handler, typename ...Args>
 void post(Handler& h, Args&& ...args)
 {
   auto ex = boost::asio::get_associated_executor(h);
-  auto a = boost::asio::get_associated_allocator(h);
   auto b = std::bind(std::move(h), std::forward<Args>(args)...);
-  ex.post(std::move(b), a);
+  boost::asio::post(bind_executor(ex, std::move(b)));
 }
 
 struct single_tuple_handler {


### PR DESCRIPTION
modernize slightly with the proposed standard executors added in boost 1.74: https://www.boost.org/doc/libs/1_74_0/doc/html/boost_asio/std_executors.html